### PR TITLE
Add database migrations

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -1,0 +1,4 @@
+#!/usr/bin/php 
+<?php
+
+require __DIR__ . "/../vendor/autoload.php";

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,4 +1,22 @@
 #!/usr/bin/php 
 <?php
 
+use DI\ContainerBuilder;
+use Shika\Database\Database;
+use Shika\Database\Migrations\Migrate;
+
 require __DIR__ . "/../vendor/autoload.php";
+
+$containerBuilder = new ContainerBuilder();
+
+$dependencies = require __DIR__ . "/../bootstrap/dependencies.php";
+$dependencies($containerBuilder);
+
+$container = $containerBuilder->build();
+
+$database = $container->get(Database::class);
+
+$migrate = new Migrate($database, "sqlite");
+$migrate->findMigrations();
+
+$migrate->migrate();

--- a/migrations/sqlite/0001_initial_create.php
+++ b/migrations/sqlite/0001_initial_create.php
@@ -18,7 +18,7 @@ return new class implements Migration
         $database->exec("
             CREATE TABLE users (
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                username    TEXT,
+                username    TEXT COLLATE NOCASE,
                 password    TEXT
             )
         ");

--- a/migrations/sqlite/0001_initial_create.php
+++ b/migrations/sqlite/0001_initial_create.php
@@ -10,36 +10,36 @@ return new class implements Migration
         $database->exec("
             CREATE TABLE sites (
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                name        TEXT,
-                site_key    TEXT
+                name        TEXT NOT NULL,
+                site_key    TEXT NOT NULL
             )
         ");
 
         $database->exec("
             CREATE TABLE users (
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                username    TEXT COLLATE NOCASE,
-                password    TEXT
+                username    TEXT COLLATE NOCASE NOT NULL,
+                password    TEXT NOT NULL
             )
         ");
 
         $database->exec("
             CREATE TABLE user_api_keys (
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                user_id     INTEGER REFERENCES users(id),
-                label       TEXT,
-                key         TEXT UNIQUE,
-                created_at  TEXT
+                user_id     INTEGER NOT NULL REFERENCES users(id),
+                label       TEXT NOT NULL,
+                key         TEXT UNIQUE NOT NULL,
+                created_at  TEXT NOT NULL
             )
         ");
 
         $database->exec("
             CREATE TABLE visits (
                 id              INTEGER PRIMARY KEY AUTOINCREMENT,
-                site_id         INTEGER REFERENCES sites(id),
-                visit_at        TEXT,
-                visit_host      TEXT,
-                visit_path      TEXT,
+                site_id         INTEGER NOT NULL REFERENCES sites(id),
+                visit_at        TEXT NOT NULL,
+                visit_host      TEXT NOT NULL,
+                visit_path      TEXT NOT NULL,
                 referrer_host   TEXT,
                 referrer_path   TEXT
             )

--- a/migrations/sqlite/0001_initial_create.php
+++ b/migrations/sqlite/0001_initial_create.php
@@ -1,0 +1,52 @@
+<?php
+
+use Shika\Database\Database;
+use Shika\Database\Migrations\Migration;
+
+return new class implements Migration
+{
+    public function up(Database $database)
+    {
+        $database->exec("
+            CREATE TABLE sites (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                name        TEXT,
+                site_key    TEXT
+            )
+        ");
+
+        $database->exec("
+            CREATE TABLE users (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                username    TEXT,
+                password    TEXT
+            )
+        ");
+
+        $database->exec("
+            CREATE TABLE user_api_keys (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id     INTEGER REFERENCES users(id),
+                label       TEXT,
+                key         TEXT UNIQUE,
+                created_at  TEXT
+            )
+        ");
+
+        $database->exec("
+            CREATE TABLE visits (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                site_id         INTEGER REFERENCES sites(id),
+                visit_at        TEXT,
+                visit_host      TEXT,
+                visit_path      TEXT,
+                referrer_host   TEXT,
+                referrer_path   TEXT
+            )
+        ");
+
+        $database->exec("CREATE INDEX ix_sites_site_key ON sites(site_key)");
+        $database->exec("CREATE INDEX ix_users_username ON users(username)");
+        $database->exec("CREATE INDEX ix_visits_site_id_visit_at ON visits(site_id, visit_at)");
+    }
+};

--- a/src/Database/Migrations/Migrate.php
+++ b/src/Database/Migrations/Migrate.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Shika\Database\Migrations;
+
+use Shika\Database\Database;
+
+class Migrate
+{    
+    private Database $database;
+
+    private string $migrationsPath;
+    private array $migrations;
+
+    public function __construct(Database $database, string $driver)
+    {
+        $this->database = $database;
+
+        $this->migrationsPath = getcwd() . DIRECTORY_SEPARATOR . "migrations" . DIRECTORY_SEPARATOR . $driver;
+        $this->migrations = [];
+    }
+
+    /**
+     * Find all migrations in the migrations folder
+     */
+    public function findMigrations()
+    {
+        $files = scandir($this->migrationsPath);
+
+        foreach ($files as $file)
+        {
+            if (strpos($file, ".php") !== false)
+            {
+                array_push($this->migrations, $file);
+            }
+        }
+    }
+
+    /**
+     * Migrate the current database
+     */
+    public function migrate()
+    {
+        $this->ensureMigrations();
+
+        // fetch the applied migrations
+        $applied = $this->database->getAll("SELECT migration FROM migrations");
+        $applied = array_map(function($migration) { return $migration->migration; }, $applied);
+
+        // remove migrations we already applied
+        $migrations = array_diff($this->migrations, $applied);
+
+        if (count($migrations) < 1)
+        {
+            echo "No migrations to apply";
+        }
+
+        foreach ($migrations as $filename)
+        {
+            $path = $this->migrationsPath . DIRECTORY_SEPARATOR . $filename;
+
+            echo $filename;
+
+            $migration = require $path;
+            $this->executeMigration($filename, $migration);
+
+            echo " \033[32mOK\033[0m\n";
+        }
+    }
+
+    private function executeMigration(string $filename, Migration $migration)
+    {
+        // execute the migration up
+        $migration->up($this->database);
+
+        // add to migration history
+        $this->database->exec("INSERT INTO migrations VALUES (?)", $filename);
+    }
+
+    private function ensureMigrations()
+    {
+        $this->database->exec("CREATE TABLE IF NOT EXISTS migrations (migration TEXT PRIMARY KEY)");
+    }
+}

--- a/src/Database/Migrations/Migrate.php
+++ b/src/Database/Migrations/Migrate.php
@@ -51,7 +51,7 @@ class Migrate
 
         if (count($migrations) < 1)
         {
-            echo "No migrations to apply";
+            echo "No migrations to apply\n";
         }
 
         foreach ($migrations as $filename)

--- a/src/Database/Migrations/Migration.php
+++ b/src/Database/Migrations/Migration.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Shika\Database\Migrations;
+
+use Shika\Database\Database;
+
+interface Migration
+{
+    public function up(Database $database);
+}


### PR DESCRIPTION
Adds a `bin/migrate` script to create and update the database. Migrations are placed in the migrations/(sqlite/mysql) folder, currently only migrations for SQLite.

The applied migrations are stored in the `migrations` table in the database.

The added migration `0001_initial_create` will create the current database schema.